### PR TITLE
Replace images functionality

### DIFF
--- a/functions/api/files.ts
+++ b/functions/api/files.ts
@@ -18,7 +18,7 @@ AWS.config.getCredentials((err) => {
 
 const compressImage = async (file: Express.Multer.File): Promise<Buffer> => {
     const image = await Jimp.read(file.buffer);
-    return await image.resize(200, Jimp.AUTO)
+    return await image.resize(250, Jimp.AUTO)
         .quality(100)
         .getBufferAsync(image.getMIME());
 };

--- a/routes/files.ts
+++ b/routes/files.ts
@@ -154,6 +154,30 @@ router.get("/get/unprotected/:name", async (req, res) => {
     });
 });
 
+// Delete an image from S3
+// Does not delete the image from anywhere else
+router.delete("/image",
+    authorizePls,
+    adminPrylisAuth,
+    query("key").isString().trim().notEmpty().withMessage("should be a string"),
+    validationCheck,
+async (req, res) => {
+    const { key } = req.query;
+
+    deleteFile(key as string)
+    .then(() => {
+        res.status(StatusCodes.OK).json({
+            statusCode: StatusCodes.OK,
+        });
+    })
+    .catch(err => {
+        console.log(err);
+        res.status(StatusCodes.NOT_FOUND).json({
+            statusCode: StatusCodes.NOT_FOUND,
+        });
+    }); 
+});
+
 router.delete("/file",
     authorizePls,
     adminPrylisAuth,


### PR DESCRIPTION
This PR adds the functionality in the frontend and backend to replace the image of a patch.

Features:
- Add new endpoint that deletes an image from S3
- FileUploader in edit patch mode where you can input a file

The image is uploaded, a minimized version is created, the images are attached to the Patch object in the DB, the old images are deleted from S3.

Additionally, images are resized to 250px instead of 200px